### PR TITLE
Fix Failed CNAME creation

### DIFF
--- a/ecs-register-service-dns-lambda.py
+++ b/ecs-register-service-dns-lambda.py
@@ -65,6 +65,7 @@ def lambda_handler(event, context):
 		)
 
 		print(response)
+		return response
 
 	# delete record
 	elif eventname == 'DeleteService':


### PR DESCRIPTION
Following the tutorial by the letter does not lead to a working environment. This is
mainly because the CNAMES are not created correctly. 
Without a return statement at this point the creation of CNAMES fails.